### PR TITLE
fix[iOS-#34] Fixes race results bug causing duplicates results

### DIFF
--- a/F1App/Interactors/HomeViewModel.swift
+++ b/F1App/Interactors/HomeViewModel.swift
@@ -50,7 +50,6 @@ class HomeViewModel: ObservableObject {
     }
     
     private func initializeData() async {
-        //await reloadDataForNewSeason()
         self.raceResultViewModel = RaceResultViewModel()
     }
     

--- a/F1App/Interactors/HomeViewModel.swift
+++ b/F1App/Interactors/HomeViewModel.swift
@@ -50,7 +50,7 @@ class HomeViewModel: ObservableObject {
     }
     
     private func initializeData() async {
-        await reloadDataForNewSeason()
+        //await reloadDataForNewSeason()
         self.raceResultViewModel = RaceResultViewModel()
     }
     

--- a/F1App/Presenters/HomeScreen.swift
+++ b/F1App/Presenters/HomeScreen.swift
@@ -174,20 +174,23 @@ struct HomeScreen: View {
                                 )
                                 .onAppear {
                                     Task {
-                                        await viewModel.fetchRaceResults(season: viewModel.seasonYear, round: "\(index + 1)")
+                                        await viewModel.fetchRaceResults(
+                                            season: viewModel.seasonYear,
+                                            round: "\(index + 1)"
+                                        )
                                     }
                                 }
                             ) {
                                 GrandPrixCards(
-                                    grandPrixName: "\(race.raceName ?? "Grand Prix")",
-                                    circuitName: "\(race.circuit?.circuitName ?? "Circuit")",
-                                    raceDate: "\(race.date ?? "Date")",
-                                    raceTime: "\(race.time ?? "Time")",
-                                    winnerName: viewModel.raceWinner[safe: index] ?? "",
-                                    winnerTeam: viewModel.winningConstructor[safe: index] ?? "",
-                                    winningTime: viewModel.winningTime[safe: index] ?? "",
-                                    fastestLap: viewModel.winnerFastestLap[safe: index] ?? "",
-                                    countryFlag: "\(race.circuit?.location?.country ?? "loading...")"
+                                    grandPrixName: "\(race.raceName ?? "⏳")",
+                                    circuitName: "\(race.circuit?.circuitName ?? "⏳")",
+                                    raceDate: "\(race.date ?? "⏳")",
+                                    raceTime: "\(race.time ?? "⏳")",
+                                    winnerName: viewModel.raceWinner[safe: index] ?? "⏳",
+                                    winnerTeam: viewModel.winningConstructor[safe: index] ?? "⏳",
+                                    winningTime: viewModel.winningTime[safe: index] ?? "⏳",
+                                    fastestLap: viewModel.winnerFastestLap[safe: index] ?? "⏳",
+                                    countryFlag: "\(race.circuit?.location?.country ?? "⏳")"
                                 )
                             }
                         }


### PR DESCRIPTION
Problem
---------
Noticed that race results are being queried twice on launch

Solution
---------
Remove initial call to load data because we gather this data in the detailed look result

Closes #34 