### PR TITLE
enh[iOS-#37] Clears race results after race is viewed

### DIFF
--- a/F1App/Interactors/HomeViewModel.swift
+++ b/F1App/Interactors/HomeViewModel.swift
@@ -62,6 +62,10 @@ class HomeViewModel: ObservableObject {
         return Int(dateFormatter.string(from: Date())) ?? 2024
     }
     
+    func clearRaceResults() {
+        raceResults2.removeAll()
+    }
+    
     @MainActor private func reloadDataForNewSeason() async {
         driverStandings.removeAll()
         constructorStandings.removeAll()

--- a/F1App/Presenters/RaceResultCards.swift
+++ b/F1App/Presenters/RaceResultCards.swift
@@ -22,6 +22,9 @@ struct RaceResultCards: View {
         }
         .background(Color.black)
         .edgesIgnoringSafeArea(.all)
+        .onDisappear() {
+            viewModel.clearRaceResults()
+        }
     }
 
     @MainActor func titleCard(title: String, titleImg: String) -> some View {


### PR DESCRIPTION
Problem
---------
When the user selects a race to view the results, if we don't clear the results 
the user can select a race that has not occurred yet and the results will be incorrect

Solution
---------
Clear the race results after viewing a race

Closes #37 