### PR TITLE
enh[iOS-#44] Expand constructor image results

### DIFF
--- a/F1App/Presenters/ConstructorsCards.swift
+++ b/F1App/Presenters/ConstructorsCards.swift
@@ -142,6 +142,7 @@ struct ConstructorsCards: View {
                 image
                     .resizable()
                     .renderingMode(.original)
+                    .scaledToFill()
                     .frame(
                         width: UIScreen.main.bounds.width - 44,
                         height: UIScreen.main.bounds.height/3

--- a/F1App/Routers/NetworkClient.swift
+++ b/F1App/Routers/NetworkClient.swift
@@ -233,7 +233,7 @@ class NetworkClient {
     
     func fetchConstructorImageFromWikipedia(constructorName: String) async throws -> String {
         let encodedName = constructorName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
-        let urlStr = "https://en.wikipedia.org/w/api.php?action=query&titles=\(encodedName)&prop=pageimages&redirects=1&format=json&pithumbsize=800"
+        let urlStr = "https://en.wikipedia.org/w/api.php?action=query&generator=search&gsrsearch=\(encodedName)%20racing%20team&prop=pageimages&format=json&gsrlimit=3&redirects=1&pithumbsize=250"
 
         guard let url = URL(string: urlStr) else {
             print(URLError(.badURL))
@@ -274,7 +274,7 @@ class NetworkClient {
         }
 
         let pageID = firstResult.pageid
-        let pageURLStr = "https://en.wikipedia.org/w/api.php?action=query&pageids=\(pageID)&prop=pageimages&format=json&pithumbsize=800"
+        let pageURLStr = "https://en.wikipedia.org/w/api.php?action=query&pageids=\(pageID)&prop=pageimages&format=json&pithumbsize=250"
 
         guard let pageURL = URL(string: pageURLStr) else {
             throw ImageFetchError.invalidURL

--- a/F1App/Routers/NetworkClient.swift
+++ b/F1App/Routers/NetworkClient.swift
@@ -233,7 +233,7 @@ class NetworkClient {
     
     func fetchConstructorImageFromWikipedia(constructorName: String) async throws -> String {
         let encodedName = constructorName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
-        let urlStr = "https://en.wikipedia.org/w/api.php?action=query&generator=search&gsrsearch=\(encodedName)%20racing%20team&prop=pageimages&format=json&gsrlimit=3&redirects=1&pithumbsize=250"
+        let urlStr = "https://en.wikipedia.org/w/api.php?action=query&generator=search&gsrsearch=\(encodedName)%20racing%20team&prop=pageimages&format=json&gsrlimit=3&redirects=1&pithumbsize=800"
 
         guard let url = URL(string: urlStr) else {
             print(URLError(.badURL))
@@ -274,7 +274,7 @@ class NetworkClient {
         }
 
         let pageID = firstResult.pageid
-        let pageURLStr = "https://en.wikipedia.org/w/api.php?action=query&pageids=\(pageID)&prop=pageimages&format=json&pithumbsize=250"
+        let pageURLStr = "https://en.wikipedia.org/w/api.php?action=query&pageids=\(pageID)&prop=pageimages&format=json&pithumbsize=800"
 
         guard let pageURL = URL(string: pageURLStr) else {
             throw ImageFetchError.invalidURL

--- a/F1App/Routers/NetworkClient.swift
+++ b/F1App/Routers/NetworkClient.swift
@@ -233,7 +233,7 @@ class NetworkClient {
     
     func fetchConstructorImageFromWikipedia(constructorName: String) async throws -> String {
         let encodedName = constructorName.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? ""
-        let urlStr = "https://en.wikipedia.org/w/api.php?action=query&generator=search&gsrsearch=\(encodedName)%20racing%20team&prop=pageimages&format=json&gsrlimit=3&redirects=1&pithumbsize=800"
+        let urlStr = "https://en.wikipedia.org/w/api.php?action=query&generator=search&gsrsearch=\(encodedName)%20racing%20team&prop=pageimages&format=json&gsrlimit=6&redirects=1&pithumbsize=800"
 
         guard let url = URL(string: urlStr) else {
             print(URLError(.badURL))


### PR DESCRIPTION
Problem
---------
The wiki url to gather constructor images only returns a single page

Solution
---------
Adjust url to return more than one page of results


Closes #44 